### PR TITLE
Pylint errors

### DIFF
--- a/prueba.py
+++ b/prueba.py
@@ -1,20 +1,21 @@
+import os
+import requests
 from fork import USERNAME
 from fork import PASSWORD
-import os, requests
 
-x=5
-y  = 6
-import requests
-z = x+y;text = "Z=11"
-if z==11:
+x = 5
+y = 6
+z = x+y
+text = "Z=11"
+if z == 11:
     print(z)
     print(x)
 print(os.chdir("/"))
 print(text)
 r = requests.get('?access_token=')
-tokens = text.split("=",(1))
+tokens = text.split("=", (1))
 print(tokens)
-numbers = [1, 2,3 ]
+numbers = [1, 2, 3]
 print(numbers)
 print(USERNAME)
 print(PASSWORD)


### PR DESCRIPTION
Your code has been analyzed by XXXX using Pylint tool to adapt it to [PEP8, the Python style guide](https://www.python.org/dev/peps/pep-0008/).
These are the pylint errors fixed in your code:
/prueba/prueba.py;5;1;C0326;Exactly one space required around assignment
/prueba/prueba.py;6;3;C0326;Exactly one space required before assignment
/prueba/prueba.py;9;4;C0326;Exactly one space required around comparison
/prueba/prueba.py;15;23;C0326;Exactly one space required after comma
/prueba/prueba.py;17;15;C0326;Exactly one space required after comma
/prueba/prueba.py;17;18;C0326;No space allowed before bracket
/prueba/prueba.py;3;0;C0410;Multiple imports on one line (os, requests)
/prueba/prueba.py;7;0;W0404;Reimport 'requests' (imported line 3)
/prueba/prueba.py;7;0;C0413;Import "import requests" should be placed at the top of the module
/prueba/prueba.py;8;8;C0321;More than one statement on a single line
/prueba/prueba.py;3;0;C0411;standard import "import os, requests" should be placed before "from fork import USERNAME"
/prueba/prueba.py;3;0;C0411;third party import "import os, requests" should be placed before "from fork import USERNAME"
/prueba/prueba.py;7;0;C0411;third party import "import requests" should be placed before "from fork import USERNAME"
/prueba/prueba.py;5;1;C0326;Exactly one space required around assignment
/prueba/prueba.py;6;3;C0326;Exactly one space required before assignment
/prueba/prueba.py;9;4;C0326;Exactly one space required around comparison
/prueba/prueba.py;15;23;C0326;Exactly one space required after comma
/prueba/prueba.py;17;15;C0326;Exactly one space required after comma
/prueba/prueba.py;17;18;C0326;No space allowed before bracket
/prueba/prueba.py;3;0;C0410;Multiple imports on one line (os, requests)
/prueba/prueba.py;7;0;W0404;Reimport 'requests' (imported line 3)
/prueba/prueba.py;7;0;C0413;Import "import requests" should be placed at the top of the module
/prueba/prueba.py;8;8;C0321;More than one statement on a single line
/prueba/prueba.py;3;0;C0411;standard import "import os, requests" should be placed before "from fork import USERNAME"
/prueba/prueba.py;3;0;C0411;third party import "import os, requests" should be placed before "from fork import USERNAME"
/prueba/prueba.py;7;0;C0411;third party import "import requests" should be placed before "from fork import USERNAME"
