### PR TITLE
Pylint errors

### DIFF
--- a/prueba.py
+++ b/prueba.py
@@ -1,20 +1,21 @@
+import os
+import requests
 from fork import USERNAME
 from fork import PASSWORD
-import os, requests
 
-x=5
-y  = 6
-import requests
-z = x+y;text = "Z=11"
-if z==11:
+x = 5
+y = 6
+z = x+y
+text = "Z=11"
+if z == 11:
     print(z)
     print(x)
 print(os.chdir("/"))
 print(text)
 r = requests.get('?access_token=')
-tokens = text.split("=",(1))
+tokens = text.split("=", (1))
 print(tokens)
-numbers = [1, 2,3 ]
+numbers = [1, 2, 3]
 print(numbers)
 print(USERNAME)
 print(PASSWORD)


### PR DESCRIPTION
Your code has been analyzed by PEP-Analyzer using Pylint tool to adapt it to [PEP8, the Python style guide](https://www.python.org/dev/peps/pep-0008/).  
These are the pylint errors fixed in your code:  
/l.garridomu/test/prueba.py;5;1;C0326;Exactly one space required around assignment  
/l.garridomu/test/prueba.py;6;3;C0326;Exactly one space required before assignment  
/l.garridomu/test/prueba.py;9;4;C0326;Exactly one space required around comparison  
/l.garridomu/test/prueba.py;15;23;C0326;Exactly one space required after comma  
/l.garridomu/test/prueba.py;17;15;C0326;Exactly one space required after comma  
/l.garridomu/test/prueba.py;17;18;C0326;No space allowed before bracket  
/l.garridomu/test/prueba.py;3;0;C0410;Multiple imports on one line (os, requests)  
/l.garridomu/test/prueba.py;7;0;W0404;Reimport 'requests' (imported line 3)  
/l.garridomu/test/prueba.py;7;0;C0413;Import "import requests" should be placed at the top of the module  
/l.garridomu/test/prueba.py;8;8;C0321;More than one statement on a single line  
/l.garridomu/test/prueba.py;3;0;C0411;standard import "import os, requests" should be placed before "from fork import USERNAME"  
/l.garridomu/test/prueba.py;3;0;C0411;third party import "import os, requests" should be placed before "from fork import USERNAME"  
/l.garridomu/test/prueba.py;7;0;C0411;third party import "import requests" should be placed before "from fork import USERNAME"  
/RaulCM-TFG/prueba/prueba.py;5;1;C0326;Exactly one space required around assignment  
/RaulCM-TFG/prueba/prueba.py;6;3;C0326;Exactly one space required before assignment  
/RaulCM-TFG/prueba/prueba.py;9;4;C0326;Exactly one space required around comparison  
/RaulCM-TFG/prueba/prueba.py;15;23;C0326;Exactly one space required after comma  
/RaulCM-TFG/prueba/prueba.py;17;15;C0326;Exactly one space required after comma  
/RaulCM-TFG/prueba/prueba.py;17;18;C0326;No space allowed before bracket  
/RaulCM-TFG/prueba/prueba.py;3;0;C0410;Multiple imports on one line (os, requests)  
/RaulCM-TFG/prueba/prueba.py;7;0;W0404;Reimport 'requests' (imported line 3)  
/RaulCM-TFG/prueba/prueba.py;7;0;C0413;Import "import requests" should be placed at the top of the module  
/RaulCM-TFG/prueba/prueba.py;8;8;C0321;More than one statement on a single line  
/RaulCM-TFG/prueba/prueba.py;3;0;C0411;standard import "import os, requests" should be placed before "from fork import USERNAME"  
/RaulCM-TFG/prueba/prueba.py;3;0;C0411;third party import "import os, requests" should be placed before "from fork import USERNAME"  
/RaulCM-TFG/prueba/prueba.py;7;0;C0411;third party import "import requests" should be placed before "from fork import USERNAME"  
